### PR TITLE
Decouple subscription from report running entierly

### DIFF
--- a/handler.ts
+++ b/handler.ts
@@ -65,13 +65,8 @@ export const migrate: APIGatewayProxyHandler = async (event, _context) => {
  * @returns {string} - success or error
  */
 export const rundlReports: APIGatewayProxyHandler = async (_, _context) => {
-  // log starting
-  // log number of subs
-  // log number of DL reports found vs making
-  // TODO switch to momment
-
+  console.dir('starting');
   const thirtyDaysAgo = moment().utc().subtract(1, 'months').format();
-
   // get all valid Subscriptions with no notification in the last 30 days 
   // what if no notification but drivers report is last 30?
   // what if no notification but drivers report is last 30? 
@@ -90,7 +85,7 @@ export const rundlReports: APIGatewayProxyHandler = async (_, _context) => {
 
 
 
-  // TODO consider some sort of group by driverlicense so we can run the report onces and easily sent it to relevant receipents so we don't rerun scrapes.
+  // TODO consider some sort of group by driverlicense so we can run the report onces and easily sent it to relevant recipients so we don't rerun scrapes.
   if (typeof subscription !== 'undefined') {
     try {
       const driverLicense = await DriverLicense.query().where('id', subscription.driverLicenseId).first();
@@ -99,9 +94,7 @@ export const rundlReports: APIGatewayProxyHandler = async (_, _context) => {
       } = await browardCountyCDLCheck(driverLicense.driverLicenseNumber);
 
       const message = await sendReportSMS(subscription.phoneNumber, driverLicense.driverLicenseNumber, reportInnerText, 'Broward County Clerk Of Courts');
-
       const messageResult = message[0];
-
       delete messageResult.body;
 
       // we need to make this much more bomb proof (make more columns optional) incase something happens.
@@ -156,7 +149,6 @@ export const rundlReports: APIGatewayProxyHandler = async (_, _context) => {
       'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Credentials': true,
     },
-    // include number and some subscription ids?
     body: JSON.stringify({
       message: 'No notifications to send'
     }, null, 2),

--- a/helpers.ts
+++ b/helpers.ts
@@ -14,8 +14,6 @@ export const formatDLReportMiamiDade = ((cases: Array<MiamiDadeDLReportCaseRespo
         `
     });
 
-    
-
     const string = `
         You have an update for the following DL number(s) ${dlNumbers.length > 1 ? dlNumbers.join(', ') : dlNumbers}
         ${DLReportBody.join('').trim()}

--- a/lib/functions/driveLegalMiamiDadeCounty.ts
+++ b/lib/functions/driveLegalMiamiDadeCounty.ts
@@ -1,0 +1,53 @@
+// const chromium = require('chrome-aws-lambda');
+
+// export const createDriveLegalAppointment = async (dlNumber : string): Promise<any>  => {
+//     // DL number requried to not include dashes
+//     const dlNumberFormated = dlNumber.replace(/-|\s/g,'');
+//     const appointmentUrl = 'https://www.jud11.flcourts.org/Drive-Legal-Appointment-Form';
+//     let browser = null;
+
+// try {
+//      browser = await chromium.puppeteer.launch({
+//       args: chromium.args,
+//       defaultViewport: chromium.defaultViewport,
+//       executablePath: await chromium.executablePath,
+//       headless: chromium.headless,
+//     });
+
+//     let page = await browser.newPage();
+//     await page.goto(browardDlUrl);
+//     const reportTableSelector = '.pmain_entry > table:nth-child(2) > tbody:nth-child(1) > tr:nth-child(2) > td:nth-child(1) > table:nth-child(3) > tbody:nth-child(1) > tr:nth-child(2) > td:nth-child(1) > table:nth-child(1)';
+//     await page.waitForSelector(reportTableSelector);
+    
+//     const reportInnerText = await page.$eval(reportTableSelector, e => e.innerText);
+//     const reporInnerHTML = await page.$eval(reportTableSelector, e => e.innerHTML);
+//     // TODO? pass screenshot back to twilio cost 0.02 to send per message
+//     // const screenshot = await page.screenshot();
+//     await browser.close();
+//     return {
+//         sendReport : true,
+//         reporInnerHTML,
+//         reportInnerText,
+//         // screenshot
+
+//     };
+
+// } catch (error) {
+//     console.dir(error);
+//     throw error;
+//   } finally {
+//     if (browser !== null) {
+//       await browser.close();
+//     }
+//   }
+// }
+
+
+// const pageDefinition = () => {
+//     return {
+//         firstNameInput: 'dnn_ctr2160_View_tbFirstName',
+//         lastNameInput: 'dnn_ctr2160_View_tbLastName',
+//         dobInput: 'dnn_ctr2160_View_RadTextBoxDob'
+//     }
+// };
+

--- a/lib/functions/trafficeDiversion.ts
+++ b/lib/functions/trafficeDiversion.ts
@@ -1,0 +1,18 @@
+// import { Counties } from "../../models/counties";
+
+// export const buildDiversion = (county: Counties) => {
+//     const MIAMIDADECOUNTY = 'https://www.jud11.flcourts.org/Drive-Legal-Appointment-Form';
+//     const BROWARDCOUNTY = 'https://www.sheriff.org/CP/Pages/PreTrial-Services-Division.aspx';
+//     const ORANGECOUNTY = 'https://www.orangecountyfl.net/Portals/0/resource%20library/jail/Pretrial%20Diversion%20Information.pdf';
+
+//     switch (county) {
+//         case Counties["MIAMI-DADE"]:
+//             return MIAMIDADECOUNTY;
+//         case Counties["BROWARD"]:
+//             return BROWARDCOUNTY;
+//         case Counties["ORANGE"]:
+//             return ORANGECOUNTY;
+//         default:
+//             return '';
+//     }
+// }

--- a/models/SubscriptionRequest.d.ts
+++ b/models/SubscriptionRequest.d.ts
@@ -1,0 +1,6 @@
+export interface SubscriptionRequest {
+    emailAddressClient: string;
+    phoneNumberClient: string;
+    driverLicenseIdClient: string;
+    countyClient: string;
+}

--- a/models/counties.ts
+++ b/models/counties.ts
@@ -1,0 +1,3 @@
+export enum Counties {
+    'MIAMI-DADE' = 'MIAMI-DADE', 'BROWARD' = 'BROWARD', 'PALM-BEACH' = 'PALM-BEACH', 'ORANGE' = 'ORANGE'
+  }

--- a/public/index.html
+++ b/public/index.html
@@ -144,7 +144,7 @@
                                 <label for="agreementClient" class="pure-checkbox">
                                     <input id="agreementInput" type="checkbox" name="agreementClient" required
                                         autocomplete="off">
-                                        I agree to the <a href="tou.html">Terms of Use</a> and understand that SMS messaging and Data rates may apply. 
+                                        I agree to the <a href="tou.html">Terms of Use</a> and agree to have Drivefine request driver license records in order to carry out our functions. SMS messaging and Data rates may apply. 
                                 </label>
                             <div class="pure-g  pure-u-5-5">
                                 <input class="pure-button pure-button-primary" id="submitSubscribeButton" type="submit" value="Subscribe">

--- a/serverless.yml
+++ b/serverless.yml
@@ -41,7 +41,7 @@ functions:
     handler: handler.migrate
   subscription:
     timeout: 60
-    memorySize: 1024
+    memorySize: 512
     handler: handler.subscription
     events:
       - http:
@@ -50,7 +50,7 @@ functions:
           cors: true
   rundlReports:
     timeout: 60
-    memorySize: 1024
+    memorySize: 2048
     handler: handler.rundlReports
     events:
-      - schedule: cron(0 0 * * ? *)
+      - schedule: cron(0/30 * * * ? *)


### PR DESCRIPTION
No need to do signup and reporting at the same time, this ticket uncouples those two things with a 30 min cron for the report running (further optimizations pending)
Has some prework for diversion information.
